### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -108,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-deb
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/cwill747/meshcore-uconsole/security/code-scanning/7](https://github.com/cwill747/meshcore-uconsole/security/code-scanning/7)

In general, you fix this by adding an explicit `permissions:` block either at the top level of the workflow (applies to all jobs) or on individual jobs, granting only the scopes each job needs. That prevents the `GITHUB_TOKEN` from inheriting potentially broad default permissions from the repository or organization.

For this workflow, the safest and simplest change without altering functionality is:
- Add a minimal read-only `permissions:` block at the workflow root (e.g., `contents: read`), which covers `commits`, `check`, and `build-deb` (they only need to read the repo and use artifacts).
- Add a more permissive `permissions:` block to the `release` job to allow it to create releases, i.e., `contents: write`. This job also uses artifacts, but `actions/upload-artifact` and `actions/download-artifact` rely on the actions infrastructure, not extra repo scopes, so no further scopes are necessary.

Concretely:
- In `.github/workflows/ci.yml`, insert a root-level `permissions:` block right after `name: CI`.
- In the same file, within the `release` job definition (just after `runs-on: ubuntu-latest` / `needs: build-deb` / `if: ...`), add `permissions:\n  contents: write`.

No additional imports or external libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
