### PR TITLE
perf: Reduce CPU/IO load on Raspberry Pi hot paths

### DIFF
--- a/src/meshcore_console/core/services.py
+++ b/src/meshcore_console/core/services.py
@@ -63,6 +63,10 @@ class MeshcoreService(Protocol):
         """
         ...
 
+    def flush_stores(self) -> None:
+        """Flush any dirty stores to disk."""
+        ...
+
     def get_gps_error(self) -> str | None:
         """Get the last GPS error message, if any."""
         ...

--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -499,6 +499,13 @@ class MeshcoreClient(MeshcoreService):
         """Return packets from persistent storage."""
         return self._packet_store.get_recent(limit)
 
+    def flush_stores(self) -> None:
+        """Flush any dirty stores to disk."""
+        self._packet_store.flush_if_dirty()
+        self._message_store.flush_if_dirty()
+        self._peer_store.flush_if_dirty()
+        self._channel_store.flush_if_dirty()
+
     def get_stored_packet_count(self) -> int:
         """Return the number of packets in persistent storage."""
         return len(self._packet_store)

--- a/src/meshcore_console/meshcore/packet_codec.py
+++ b/src/meshcore_console/meshcore/packet_codec.py
@@ -4,6 +4,12 @@ from typing import Any
 
 from meshcore_console.core.types import PacketDataDict
 
+try:
+    from pymc_core.protocol.utils import PAYLOAD_TYPES, ROUTE_TYPES
+except ImportError:
+    PAYLOAD_TYPES = {}
+    ROUTE_TYPES = {}
+
 
 def _extract_sender_name(packet: Any) -> str | None:
     """Try to extract sender/peer name from packet via various attributes."""
@@ -162,15 +168,8 @@ def packet_to_dict(packet: Any) -> PacketDataDict:
     except Exception:
         route_type = None
 
-    try:
-        from pymc_core.protocol.utils import PAYLOAD_TYPES, ROUTE_TYPES
-
-        payload_type_name = (
-            PAYLOAD_TYPES.get(payload_type, None) if payload_type is not None else None
-        )
-        route_type_name = ROUTE_TYPES.get(route_type, None) if route_type is not None else None
-    except Exception:
-        route_type_name = None
+    payload_type_name = PAYLOAD_TYPES.get(payload_type, None) if payload_type is not None else None
+    route_type_name = ROUTE_TYPES.get(route_type, None) if route_type is not None else None
 
     payload_text = None
     payload_hex = None
@@ -261,5 +260,5 @@ def packet_to_dict(packet: Any) -> PacketDataDict:
         "path_len": path_len,
         "path_hops": path_hops,
         "packet_hash": packet_hash,
-        "raw": repr(packet),
+        "raw": None,
     }

--- a/src/meshcore_console/mock/client.py
+++ b/src/meshcore_console/mock/client.py
@@ -160,6 +160,9 @@ class MockMeshcoreClient(MeshcoreService):
     def list_stored_packets(self, limit: int = 100) -> list[dict]:
         return []
 
+    def flush_stores(self) -> None:
+        """No-op for mock client (no persistent stores)."""
+
     def get_stored_packet_count(self) -> int:
         return 0
 

--- a/src/meshcore_console/ui_gtk/state/event_store.py
+++ b/src/meshcore_console/ui_gtk/state/event_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import deque
+
 from meshcore_console.core.services import MeshcoreService
 from meshcore_console.core.types import MeshEventDict
 
@@ -7,23 +9,20 @@ from meshcore_console.core.types import MeshEventDict
 class UiEventStore:
     def __init__(self, service: MeshcoreService) -> None:
         self._service = service
-        self._events: list[tuple[int, MeshEventDict]] = []
+        self._events: deque[tuple[int, MeshEventDict]] = deque(maxlen=500)
         self._seq = 0
-        self._max_events = 500
 
     def pump(self, limit: int = 100) -> list[MeshEventDict]:
         events = self._service.poll_events(limit=limit)
         for event in events:
             self._seq += 1
             self._events.append((self._seq, event))
-        if len(self._events) > self._max_events:
-            self._events = self._events[-self._max_events :]
         return events
 
     def recent(self, limit: int = 50) -> list[MeshEventDict]:
         if limit <= 0:
             return []
-        return [event for _, event in self._events[-limit:]]
+        return [event for _, event in list(self._events)[-limit:]]
 
     def since(self, cursor: int, limit: int = 100) -> tuple[int, list[MeshEventDict]]:
         items = [event for seq, event in self._events if seq > cursor]

--- a/src/meshcore_console/ui_gtk/windows/main_window.py
+++ b/src/meshcore_console/ui_gtk/windows/main_window.py
@@ -393,6 +393,7 @@ class MainWindow(Adw.ApplicationWindow):
             if event.get("type") == "settings_updated":
                 self._refresh_connection_state()
                 break
+        self._service.flush_stores()
         return True
 
     def _wire_keyboard_shortcuts(self) -> None:


### PR DESCRIPTION
- Incremental analyzer stream: prepend only new rows instead of rebuilding all 900 widgets every poll; use deque(maxlen=400); increase poll interval from 750ms to 1500ms
- Debounced store persistence: stores set dirty flag on mutation and flush to disk at most once per second via the pump timer
- Remove repr(packet) from packet codec to avoid large string allocation per packet
- Hoist pymc_core import to module level to avoid per-packet import
- Incremental message updates: append only new messages instead of full rebuild
- Replace print(stderr) with logging in PacketStore
- Use deque for UiEventStore to avoid list reallocation on trim