### PR TITLE
fix: Use dtoverlay=spi1-1cs instead of raspi-config for SPI1 enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,13 @@ MESHCORE_MOCK=1 ./scripts/run-gtk-pi.sh
 ### Hardware Troubleshooting
 
 If `doctor` fails on SPI/GPIO, confirm these before retrying:
-- SPI is enabled (`sudo raspi-config nonint do_spi 0`)
-- `/boot/firmware/config.txt` contains `dtoverlay=spi1-1cs`
-- You rebooted after bootstrap
+- `/boot/firmware/config.txt` contains `dtoverlay=spi1-1cs` (enables SPI1 for the radio)
+- You rebooted after adding the overlay
+
+> **Warning:** Do not run `sudo raspi-config nonint do_spi 0` — this enables
+> SPI0 (`dtparam=spi=on`), not SPI1, and on CM5 + Trixie it can disable the
+> uConsole internal display. If this has happened, remove `dtparam=spi=on`
+> from `/boot/firmware/config.txt` via SSH and reboot.
 
 Hardware overrides can be supplied via env vars when running `meshcore-console`.
 Notable radio bring-up flags:

--- a/scripts/bootstrap-pi.sh
+++ b/scripts/bootstrap-pi.sh
@@ -46,8 +46,6 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
-sudo raspi-config nonint do_spi 0 || true
-
 BOOT_CONFIG=""
 if [[ -f /boot/firmware/config.txt ]]; then
   BOOT_CONFIG="/boot/firmware/config.txt"
@@ -61,11 +59,6 @@ fi
 if ! grep -q '^dtoverlay=spi1-1cs$' "$BOOT_CONFIG"; then
   echo "Enabling SPI1 overlay (dtoverlay=spi1-1cs)"
   echo 'dtoverlay=spi1-1cs' | sudo tee -a "$BOOT_CONFIG" >/dev/null
-fi
-
-if ! grep -q '^dtparam=spi=on$' "$BOOT_CONFIG"; then
-  echo "Enabling SPI dtparam (dtparam=spi=on)"
-  echo 'dtparam=spi=on' | sudo tee -a "$BOOT_CONFIG" >/dev/null
 fi
 
 if systemctl list-unit-files | grep -q '^devterm-printer.service'; then

--- a/src/meshcore_console/platform/conflicts.py
+++ b/src/meshcore_console/platform/conflicts.py
@@ -104,13 +104,39 @@ def _check_spi_device(bus_id: int, cs_id: int) -> Conflict | None:
         fd = os.open(path, os.O_RDWR)
         os.close(fd)
     except FileNotFoundError:
+        if bus_id >= 1:
+            detail_text = (
+                f"The SPI device {path} does not exist. "
+                f"The dtoverlay=spi{bus_id}-1cs overlay may not be enabled "
+                f"in /boot/firmware/config.txt."
+            )
+            remediation_text = (
+                f"sudo sh -c 'echo dtoverlay=spi{bus_id}-1cs "
+                f">> /boot/firmware/config.txt'\n"
+                f"sudo reboot\n"
+                f"\n"
+                f"WARNING: Do NOT use 'raspi-config nonint do_spi 0' — that\n"
+                f"enables SPI0, not SPI{bus_id}, and can disable the uConsole\n"
+                f"internal display on CM5 + Trixie."
+            )
+        else:
+            detail_text = (
+                f"The SPI device {path} does not exist. "
+                f"SPI may not be enabled in /boot/firmware/config.txt."
+            )
+            remediation_text = (
+                "sudo raspi-config nonint do_spi 0\n"
+                "sudo reboot\n"
+                "\n"
+                "NOTE: On uConsole CM5 + Trixie this command can disable the\n"
+                "internal display. If that happens, remove 'dtparam=spi=on'\n"
+                "from /boot/firmware/config.txt via SSH and reboot."
+            )
         return Conflict(
             kind=ConflictType.SPI_DEVICE,
             summary=f"{path} not found",
-            detail=(
-                f"The SPI device {path} does not exist. SPI may not be enabled in /boot/config.txt."
-            ),
-            remediation="sudo raspi-config nonint do_spi 0",
+            detail=detail_text,
+            remediation=remediation_text,
         )
     except PermissionError:
         return Conflict(

--- a/src/meshcore_console/radio_cli.py
+++ b/src/meshcore_console/radio_cli.py
@@ -74,7 +74,7 @@ def _doctor() -> int:
     checks: list[tuple[str, bool, str]] = []
     checks.append(("linux", os.uname().sysname == "Linux", "Expected Linux host"))
     checks.append(
-        ("spidev", os.path.exists("/dev/spidev1.0"), "Expected SPI1 device /dev/spidev1.0")
+        ("spidev", os.path.exists("/dev/spidev1.0"), "Expected SPI1 device /dev/spidev1.0 — ensure dtoverlay=spi1-1cs is in /boot/firmware/config.txt")
     )
     checks.append(
         ("gpiochip", os.path.exists("/dev/gpiochip0"), "Expected GPIO chip /dev/gpiochip0")

--- a/src/meshcore_console/radio_cli.py
+++ b/src/meshcore_console/radio_cli.py
@@ -74,7 +74,11 @@ def _doctor() -> int:
     checks: list[tuple[str, bool, str]] = []
     checks.append(("linux", os.uname().sysname == "Linux", "Expected Linux host"))
     checks.append(
-        ("spidev", os.path.exists("/dev/spidev1.0"), "Expected SPI1 device /dev/spidev1.0 — ensure dtoverlay=spi1-1cs is in /boot/firmware/config.txt")
+        (
+            "spidev",
+            os.path.exists("/dev/spidev1.0"),
+            "Expected SPI1 device /dev/spidev1.0 — ensure dtoverlay=spi1-1cs is in /boot/firmware/config.txt",
+        )
     )
     checks.append(
         ("gpiochip", os.path.exists("/dev/gpiochip0"), "Expected GPIO chip /dev/gpiochip0")


### PR DESCRIPTION
raspi-config nonint do_spi 0 enables SPI0 (dtparam=spi=on), not SPI1, and can disable the uConsole internal display on CM5 + Trixie. Replace with the correct dtoverlay=spi1-1cs guidance in the conflict screen, bootstrap script, doctor command, and README.

Closes #53