### PR TITLE
fix: Don't re-apply presets on settings save, preserving user edits

### DIFF
--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -20,11 +20,7 @@ from meshcore_console.meshcore.logging_setup import install_radio_error_handler
 from meshcore_console.meshcore.packet_codec import repair_utf8
 from meshcore_console.meshcore.packet_store import PacketStore
 from meshcore_console.meshcore.session import PyMCCoreSession
-from meshcore_console.meshcore.settings import (
-    MeshcoreSettings,
-    apply_hardware_preset,
-    apply_preset,
-)
+from meshcore_console.meshcore.settings import MeshcoreSettings
 from meshcore_console.meshcore.settings_store import SettingsStore
 from meshcore_console.meshcore.state_store import MessageStore, PeerStore, UIChannelStore
 from meshcore_console.platform.gps import GpsProvider, create_gps_provider
@@ -738,11 +734,6 @@ class MeshcoreClient(MeshcoreService):
 
     def update_settings(self, settings: MeshcoreSettings) -> None:
         updated = settings.clone()
-        if updated.hardware_preset != "custom":
-            updated = apply_hardware_preset(updated, updated.hardware_preset)
-        if updated.radio_preset != "custom":
-            updated = apply_preset(updated, updated.radio_preset)
-
         self._settings = updated
         self._settings_store.save(updated)
         self._config = runtime_config_from_settings(self._settings)

--- a/tests/integration/test_settings_apply.py
+++ b/tests/integration/test_settings_apply.py
@@ -21,15 +21,16 @@ def test_client_updates_and_persists_settings(tmp_path) -> None:
     settings.share_position = True
     settings.latitude = 47.6
     settings.radio_preset = "meshcore-us"
-    settings.frequency = 1
+    settings.frequency = 915_000_000
+    settings.coding_rate = 8
 
     client.update_settings(settings)
     updated = client.get_settings()
     assert updated.node_name == "applied-node"
     assert updated.share_position is True
     assert updated.latitude == 47.6
-    # preset application should override custom frequency with preset value
-    assert updated.frequency == 910_525_000
+    assert updated.frequency == 915_000_000
+    assert updated.coding_rate == 8
 
     reloaded = store.load()
     assert reloaded.node_name == "applied-node"


### PR DESCRIPTION
## Summary
- **Fixes #54** — coding rate (and all radio/hardware fields) were silently reverted to preset defaults on save
- `update_settings()` was re-applying `apply_preset()`/`apply_hardware_preset()` before persisting, overwriting user edits. The UI already applies presets when the dropdown changes, so re-applying on save was redundant and destructive.
- Updated integration test to verify user-modified values are preserved

## Test plan
- [x] All 85 tests pass
- [ ] Run in mock mode, change coding rate, save, reload — verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)