### PR TITLE
fix: Use PacketBuilder for send ops (pymc-core 1.0.10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-  "pymc-core>=0.1.0",
-  "pymc-core[hardware]>=0.1.0; platform_system == 'Linux'",
+  "pymc-core>=1.0.10",
+  "pymc-core[hardware]>=1.0.10; platform_system == 'Linux'",
   "pynmea2>=1.18.0",
   "segno>=1.6.0",  # QR code generation
   "gpsdclient>=1.3",

--- a/src/meshcore_console/core/types.py
+++ b/src/meshcore_console/core/types.py
@@ -124,19 +124,32 @@ class LocalIdentityProtocol(Protocol):
 class DispatcherProtocol(Protocol):
     """Protocol for pyMC_core dispatcher."""
 
+    protocol_response_handler: Any
+
     def set_raw_packet_callback(self, cb: Callable[..., Awaitable[None]]) -> None:
         """Set callback for raw packets."""
         ...
 
-    async def send_packet(self, packet: object, wait_for_ack: bool = False) -> object:
+    async def send_packet(
+        self, packet: object, wait_for_ack: bool = False, **kwargs: Any
+    ) -> object:
         """Send a packet through the mesh."""
         ...
 
 
 class MeshNodeProtocol(Protocol):
-    """Protocol for pyMC_core MeshNode."""
+    """Protocol for pyMC_core MeshNode.
+
+    As of pyMC_core 1.0.10, MeshNode exposes low-level primitives
+    (send_packet, dispatcher, identity, contacts, etc.) and packet
+    construction is done via PacketBuilder.
+    """
 
     dispatcher: DispatcherProtocol
+    identity: Any
+    contacts: Any
+    channel_db: Any
+    node_name: str
 
     def set_event_service(self, service: EventServiceProtocol) -> None:
         """Set the event service for this node."""
@@ -150,23 +163,8 @@ class MeshNodeProtocol(Protocol):
         """Stop the mesh node. May return awaitable."""
         ...
 
-    async def send_text(self, peer_name: str, message: str) -> object:
-        """Send a text message to a peer."""
-        ...
-
-    async def send_group_text(self, channel_name: str, message: str) -> object:
-        """Send a text message to a group channel."""
-        ...
-
-    async def send_telemetry_request(
-        self,
-        contact_name: str,
-        want_base: bool = True,
-        want_location: bool = True,
-        want_environment: bool = False,
-        timeout: float = 10.0,
-    ) -> dict:
-        """Request telemetry data from a remote peer."""
+    async def send_packet(self, pkt: object, *, wait_for_ack: bool = False, **kwargs: Any) -> bool:
+        """Send a packet through the mesh."""
         ...
 
 

--- a/src/meshcore_console/meshcore/operations.py
+++ b/src/meshcore_console/meshcore/operations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import time
+
 from meshcore_console.core.types import (
     EmitCallback,
     LocalIdentityProtocol,
@@ -9,13 +12,46 @@ from meshcore_console.core.types import (
 )
 
 
-async def send_text(*, node: MeshNodeProtocol, peer_name: str, message: str) -> object:
-    return await node.send_text(peer_name, message)
+async def send_text(*, node: MeshNodeProtocol, peer_name: str, message: str) -> dict:
+    """Send a direct text message to a peer via PacketBuilder."""
+    from pymc_core.protocol.packet_builder import PacketBuilder
+
+    contacts = node.contacts
+    contact = None
+    if contacts is not None:
+        contact = contacts.get_by_name(peer_name)
+    if contact is None:
+        raise RuntimeError(f"Contact '{peer_name}' not found")
+
+    pkt, ack_crc = PacketBuilder.create_text_message(
+        contact=contact,
+        local_identity=node.identity,
+        message=message,
+    )
+    success = await node.dispatcher.send_packet(pkt, wait_for_ack=True, expected_crc=ack_crc)
+    return {"success": success, "crc": ack_crc}
 
 
-async def send_group_text(*, node: MeshNodeProtocol, channel_name: str, message: str) -> object:
-    """Broadcast a text message to a group/public channel."""
-    return await node.send_group_text(channel_name, message)
+async def send_group_text(*, node: MeshNodeProtocol, channel_name: str, message: str) -> dict:
+    """Broadcast a text message to a group/public channel via PacketBuilder."""
+    from pymc_core.protocol.packet_builder import PacketBuilder
+
+    channels_config = []
+    if node.channel_db is not None:
+        try:
+            channels_config = node.channel_db.get_channels()
+        except Exception:
+            channels_config = []
+
+    pkt = PacketBuilder.create_group_datagram(
+        group_name=channel_name,
+        local_identity=node.identity,
+        message=message,
+        sender_name=node.node_name,
+        channels_config=channels_config,
+    )
+    success = await node.dispatcher.send_packet(pkt, wait_for_ack=False)
+    return {"success": success, "group": channel_name}
 
 
 async def request_telemetry(
@@ -25,14 +61,69 @@ async def request_telemetry(
     want_location: bool = True,
     timeout: float = 10.0,
 ) -> dict:
-    """Request telemetry data from a remote peer."""
-    return await node.send_telemetry_request(
-        contact_name,
+    """Request telemetry data from a remote peer via PacketBuilder."""
+    from pymc_core.protocol.packet_builder import PacketBuilder
+
+    contacts = node.contacts
+    contact = None
+    if contacts is not None:
+        contact = contacts.get_by_name(contact_name)
+    if contact is None:
+        raise RuntimeError(f"Contact '{contact_name}' not found")
+
+    pkt, _ts = PacketBuilder.create_telem_request(
+        contact=contact,
+        local_identity=node.identity,
         want_base=True,
         want_location=want_location,
         want_environment=False,
-        timeout=timeout,
     )
+
+    contact_hash = bytes.fromhex(contact.public_key)[0]
+    response_handler = node.dispatcher.protocol_response_handler
+
+    response_event = asyncio.Event()
+    response_data: dict = {}
+
+    def _on_response(data: dict) -> None:
+        response_data.update(data)
+        response_event.set()
+
+    response_handler.set_response_callback(contact_hash, _on_response)
+    t0 = time.monotonic()
+    try:
+        await node.dispatcher.send_packet(pkt, wait_for_ack=False)
+        got_response = await asyncio.wait_for(response_event.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        got_response = False
+    finally:
+        response_handler.clear_response_callback(contact_hash)
+
+    rtt = (time.monotonic() - t0) * 1000
+
+    if not got_response:
+        return {
+            "success": False,
+            "contact": contact_name,
+            "requested": {"base": True, "location": want_location, "environment": False},
+            "telemetry_data": None,
+            "rtt_ms": round(rtt, 2),
+            "reason": f"Telemetry response timeout after {timeout}s",
+        }
+
+    return {
+        "success": response_data.get("success", False),
+        "contact": contact_name,
+        "requested": {"base": True, "location": want_location, "environment": False},
+        "telemetry_data": response_data.get("parsed"),
+        "response_text": response_data.get("text"),
+        "rtt_ms": round(rtt, 2),
+        "reason": (
+            "Telemetry response received"
+            if response_data.get("success")
+            else "Telemetry request failed"
+        ),
+    }
 
 
 async def send_advert(

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -43,7 +43,7 @@ from .config import RuntimeRadioConfig, load_hardware_config_from_env
 from .contact_book import ContactBook
 from .db import open_db
 from .event_bridge import attach_dispatcher_callbacks, attach_event_service_subscriber
-from .operations import send_advert, send_group_text, send_text
+from .operations import request_telemetry, send_advert, send_group_text, send_text
 from .runtime import create_mesh_node, create_radio, import_pymc_core
 
 
@@ -444,11 +444,10 @@ class PyMCCoreSession:
         """Request telemetry from a remote peer. Returns decoded sensor data."""
         if self._node is None:
             raise RuntimeError("Session is not started.")
-        return await self._node.send_telemetry_request(
-            contact_name,
-            want_base=True,
+        return await request_telemetry(
+            node=self._node,
+            contact_name=contact_name,
             want_location=want_location,
-            want_environment=False,
             timeout=timeout,
         )
 
@@ -472,8 +471,17 @@ class PyMCCoreSession:
             "connected": self._node is not None,
             "node_name": self.config.node_name,
             "board": "hackergadgets-aio",
-            "pymc_core_version": "1.0.7",
+            "pymc_core_version": self._get_pymc_version(),
         }
+
+    @staticmethod
+    def _get_pymc_version() -> str:
+        try:
+            import pymc_core
+
+            return pymc_core.__version__
+        except Exception:
+            return "unknown"
 
     @property
     def contact_book(self) -> ContactBook:

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "meshcore-uconsole"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "gpsdclient" },
@@ -562,8 +562,8 @@ requires-dist = [
     { name = "gpsdclient", specifier = ">=1.3" },
     { name = "pycayennelpp", specifier = ">=2.4.0" },
     { name = "pygobject", marker = "extra == 'gtk'", specifier = ">=3.48" },
-    { name = "pymc-core", specifier = ">=0.1.0" },
-    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=0.1.0" },
+    { name = "pymc-core", specifier = ">=1.0.7" },
+    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=1.0.7" },
     { name = "pynmea2", specifier = ">=1.18.0" },
     { name = "segno", specifier = ">=1.6.0" },
 ]
@@ -791,22 +791,23 @@ sdist = { url = "https://files.pythonhosted.org/packages/d3/a5/68f883df1d8442e3b
 
 [[package]]
 name = "pymc-core"
-version = "1.0.7"
+version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycryptodome" },
     { name = "pynacl" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/d8/182eb232d3d1ecaeacb2f2901ffd3dcb21893cfd7cf6b290ec0ab7c8bbb9/pymc_core-1.0.7.tar.gz", hash = "sha256:96eb511c2a8b7d739dfb73275dc737836414c97bc6fbc603ec1bf12fade2c90d", size = 129663, upload-time = "2026-01-12T21:51:45.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/72/d4747766cd6f3858382f838da47c51f27dc22c7fa879c6be4b105fd79782/pymc_core-1.0.10.tar.gz", hash = "sha256:e135fe7d6d918ae83a30ae1a915ebd5a270dd87a053a9dc8e9df8c670a31d1a5", size = 263681, upload-time = "2026-04-24T15:00:57.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/8c/ac0a82f9b5662e033dd77fdd607f950a2ca839822930d0e39bc13bf8f206/pymc_core-1.0.7-py3-none-any.whl", hash = "sha256:d8ca56ecb0b0da4cca15df1b5e53a6843d031b2ce08eda03166935407298634f", size = 131661, upload-time = "2026-01-12T21:51:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5f/7b99f0266ea38b92c327070ad07a71ce0acaead243976dec7ee6c0c6d9ea/pymc_core-1.0.10-py3-none-any.whl", hash = "sha256:6a50670d8e37ab13927c19d406d212fe0e2ecf1c3187f0555591b2fd245b9003", size = 233519, upload-time = "2026-04-24T15:00:55.742Z" },
 ]
 
 [package.optional-dependencies]
 hardware = [
     { name = "pyserial", marker = "sys_platform == 'linux'" },
     { name = "python-periphery", marker = "sys_platform == 'linux'" },
+    { name = "pyusb", marker = "sys_platform == 'linux'" },
     { name = "spidev", marker = "sys_platform == 'linux'" },
 ]
 
@@ -913,6 +914,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/f1/1a986ad2bb696033168db2121151e5ff90df033af780ffca47c8bb559f29/python-periphery-2.4.1.tar.gz", hash = "sha256:61d461d736982a6f766e878720ab10a68151e2e8c1086600d9389ac47e40e88a", size = 35407, upload-time = "2023-04-21T06:19:22.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/b8/423ab1d47cb61efc54461107177abb69a1390ac84885eff3ba83a00fd8f4/python_periphery-2.4.1-py2.py3-none-any.whl", hash = "sha256:8ab14002e7520966fae7a3b9c56d98ddaf4c1b78c5f5b2c7153cedc3846fd56a", size = 36362, upload-time = "2023-04-21T06:19:20.176Z" },
+]
+
+[[package]]
+name = "pyusb"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6b/ce3727395e52b7b76dfcf0c665e37d223b680b9becc60710d4bc08b7b7cb/pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e", size = 77281, upload-time = "2025-01-08T23:45:01.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430", size = 58465, upload-time = "2025-01-08T23:45:00.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Rewrites `send_text`, `send_group_text`, and `request_telemetry` in `operations.py` to build packets via `PacketBuilder` and send through `node.dispatcher.send_packet()`, matching the pattern `send_advert` already used
- Updates `MeshNodeProtocol` to reflect the 1.0.10 API (low-level primitives instead of high-level send methods)
- Bumps pymc-core dependency to `>=1.0.10` and updates the lock

Fixes #60

## Test plan
- [x] Verify mock mode still works (`MESHCORE_MOCK=1 ./scripts/run-dev.sh`)
- [x] Test sending a direct message on real hardware
- [x] Test sending a group/channel message on real hardware
- [ ] Test telemetry request on real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)