### PR TITLE
fix: Correct codex-generated PacketBuilder bugs from #61

### DIFF
--- a/src/meshcore_console/core/types.py
+++ b/src/meshcore_console/core/types.py
@@ -163,10 +163,6 @@ class MeshNodeProtocol(Protocol):
         """Stop the mesh node. May return awaitable."""
         ...
 
-    async def send_packet(self, pkt: object, *, wait_for_ack: bool = False, **kwargs: Any) -> bool:
-        """Send a packet through the mesh."""
-        ...
-
 
 class EventSubscriberProtocol(Protocol):
     """Protocol for pyMC_core EventSubscriber."""

--- a/src/meshcore_console/meshcore/operations.py
+++ b/src/meshcore_console/meshcore/operations.py
@@ -36,12 +36,9 @@ async def send_group_text(*, node: MeshNodeProtocol, channel_name: str, message:
     """Broadcast a text message to a group/public channel via PacketBuilder."""
     from pymc_core.protocol.packet_builder import PacketBuilder
 
-    channels_config = []
-    if node.channel_db is not None:
-        try:
-            channels_config = node.channel_db.get_channels()
-        except Exception:
-            channels_config = []
+    if node.channel_db is None:
+        raise RuntimeError("No channel database configured")
+    channels_config = node.channel_db.get_channels()
 
     pkt = PacketBuilder.create_group_datagram(
         group_name=channel_name,
@@ -85,8 +82,10 @@ async def request_telemetry(
     response_event = asyncio.Event()
     response_data: dict = {}
 
-    def _on_response(data: dict) -> None:
-        response_data.update(data)
+    def _on_response(success: bool, text: str, parsed: dict) -> None:
+        response_data["success"] = success
+        response_data["text"] = text
+        response_data["parsed"] = parsed
         response_event.set()
 
     response_handler.set_response_callback(contact_hash, _on_response)

--- a/uv.lock
+++ b/uv.lock
@@ -562,8 +562,8 @@ requires-dist = [
     { name = "gpsdclient", specifier = ">=1.3" },
     { name = "pycayennelpp", specifier = ">=2.4.0" },
     { name = "pygobject", marker = "extra == 'gtk'", specifier = ">=3.48" },
-    { name = "pymc-core", specifier = ">=1.0.7" },
-    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=1.0.7" },
+    { name = "pymc-core", specifier = ">=1.0.10" },
+    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=1.0.10" },
     { name = "pynmea2", specifier = ">=1.18.0" },
     { name = "segno", specifier = ">=1.6.0" },
 ]


### PR DESCRIPTION
## Summary
- Fix `request_telemetry` callback signature: `set_response_callback` invokes with `(success, text, parsed)` but the handler only accepted `(data)`, causing a `TypeError` on every telemetry response
- Stop silently swallowing `channel_db` errors in `send_group_text` — raise a clear `RuntimeError` instead of falling through to a confusing `PacketBuilder` `ValueError`
- Remove unused `MeshNodeProtocol.send_packet` (all callers use `node.dispatcher.send_packet()` directly)
- Fix `uv.lock` version constraint to match `pyproject.toml` (`>=1.0.10`, was `>=1.0.7`)

Fixes bugs introduced in #61.

## Test plan
- [x] All existing tests pass
- [ ] Test telemetry request on real hardware (was broken before this fix)
- [ ] Test group message send on real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)