### PR TITLE
fix: Propagate routing fields to message events

### DIFF
--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -27,6 +27,15 @@ from meshcore_console.platform.gps import GpsProvider, create_gps_provider
 
 logger = logging.getLogger(__name__)
 
+_ROUTING_FIELDS = ("path_hops", "path_len", "snr", "rssi")
+
+
+def _propagate_routing_fields(packet_data: dict, handler_data: dict) -> None:
+    for key in _ROUTING_FIELDS:
+        val = packet_data.get(key)
+        if val is not None and handler_data.get(key) is None:
+            handler_data[key] = list(val) if isinstance(val, list) else val
+
 
 class MeshcoreClient(MeshcoreService):
     """pyMC_core-backed adapter for the UI layer."""
@@ -436,17 +445,20 @@ class MeshcoreClient(MeshcoreService):
                         packet_hash = target.get("packet_hash")
                         if packet_hash:
                             self._packet_store.update_by_hash(packet_hash, updates)
+                    _propagate_routing_fields(target, data)
 
             elif event_type == EventType.MESH_MESSAGE_NEW:
-                sender = data.get("sender_name") or data.get("peer_name")
-                if sender and self._unenriched_txt:
+                if self._unenriched_txt:
                     target = self._unenriched_txt.popleft()
-                    target["sender_name"] = repair_utf8(str(sender))
-                    packet_hash = target.get("packet_hash")
-                    if packet_hash:
-                        self._packet_store.update_by_hash(
-                            packet_hash, {"sender_name": target["sender_name"]}
-                        )
+                    sender = data.get("sender_name") or data.get("peer_name")
+                    if sender:
+                        target["sender_name"] = repair_utf8(str(sender))
+                        packet_hash = target.get("packet_hash")
+                        if packet_hash:
+                            self._packet_store.update_by_hash(
+                                packet_hash, {"sender_name": target["sender_name"]}
+                            )
+                    _propagate_routing_fields(target, data)
 
     def _enrich_stored_sender_names(self, events: list[MeshEventDict]) -> None:
         """Enrich stored packet events with sender names from the peer registry."""

--- a/uv.lock
+++ b/uv.lock
@@ -562,8 +562,8 @@ requires-dist = [
     { name = "gpsdclient", specifier = ">=1.3" },
     { name = "pycayennelpp", specifier = ">=2.4.0" },
     { name = "pygobject", marker = "extra == 'gtk'", specifier = ">=3.48" },
-    { name = "pymc-core", specifier = ">=1.0.7" },
-    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=1.0.7" },
+    { name = "pymc-core", specifier = ">=1.0.10" },
+    { name = "pymc-core", extras = ["hardware"], marker = "sys_platform == 'linux'", specifier = ">=1.0.10" },
     { name = "pynmea2", specifier = ">=1.18.0" },
     { name = "segno", specifier = ">=1.6.0" },
 ]


### PR DESCRIPTION
## Summary
- Propagate `path_hops`, `path_len`, `snr`, and `rssi` from raw packet events to EventService handler events during the existing correlation step
- EventService events carry decrypted message text but lack routing info from the raw packet, so message details always showed "Hops: Direct" regardless of actual hop count
- Also fixes deque desync in `MESH_MESSAGE_NEW` handling — previously skipped popping when sender was absent, misaligning subsequent correlations

Closes #52

## Test plan
- [ ] Run in mock mode (`MESHCORE_MOCK=1`) and verify message details show correct hop counts for multi-hop messages
- [ ] Verify direct (0-hop) messages still show "Direct"
- [ ] Verify route visualization appears for messages with `path_hops`
- [ ] Confirm peers tab path display is unaffected
- [ ] Run `uv run pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)