### PR TITLE
fix: Use settings fixed position in adverts, telemetry, and map

### DIFF
--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -326,7 +326,14 @@ class MeshcoreClient(MeshcoreService):
     def send_advert(self, name: str | None = None, *, route_type: str = "flood") -> SendResultDict:
         if not self._connected:
             self.connect()
-        result = self._run_async(self._session.send_advert(name=name, route_type=route_type))
+        lat, lon = 0.0, 0.0
+        if self._settings.share_position:
+            pos = self._resolve_position()
+            if pos:
+                lat, lon = pos
+        result = self._run_async(
+            self._session.send_advert(name=name, lat=lat, lon=lon, route_type=route_type)
+        )
         self._append_event(
             {
                 "type": EventType.ADVERT_SENT,
@@ -760,8 +767,31 @@ class MeshcoreClient(MeshcoreService):
             {"type": EventType.SETTINGS_UPDATED, "data": {"node_name": updated.node_name}}
         )
 
+    @staticmethod
+    def _valid_coords(lat: float, lon: float) -> bool:
+        import math
+
+        return (
+            math.isfinite(lat)
+            and math.isfinite(lon)
+            and -90.0 <= lat <= 90.0
+            and -180.0 <= lon <= 180.0
+            and (lat != 0.0 or lon != 0.0)
+        )
+
+    def _resolve_position(self, *, use_settings: bool = True) -> tuple[float, float] | None:
+        """Live GPS first, then settings fixed position as fallback."""
+        loc = self._gps_provider.get_location()
+        if loc and self._valid_coords(loc[0], loc[1]):
+            return loc
+        if use_settings:
+            lat, lon = self._settings.latitude, self._settings.longitude
+            if self._valid_coords(lat, lon):
+                return (lat, lon)
+        return None
+
     def get_device_location(self) -> tuple[float, float] | None:
-        return self._gps_provider.get_location()
+        return self._resolve_position(use_settings=self._settings.share_position)
 
     def _on_radio_error(self, message: str) -> None:
         """Callback from RadioErrorHandler — emit as a UI event."""
@@ -816,11 +846,11 @@ class MeshcoreClient(MeshcoreService):
 
     def _get_local_telemetry(self) -> dict:
         """Provide local telemetry data for inbound requests."""
-        loc = self._gps_provider.get_location()
+        pos = self._resolve_position(use_settings=self._settings.allow_telemetry)
         return {
             "allow": self._settings.allow_telemetry,
-            "lat": loc[0] if loc else None,
-            "lon": loc[1] if loc else None,
+            "lat": pos[0] if pos else None,
+            "lon": pos[1] if pos else None,
         }
 
     def _seed_contact_book(self) -> None:

--- a/src/meshcore_console/platform/gps.py
+++ b/src/meshcore_console/platform/gps.py
@@ -513,6 +513,31 @@ def _gpsd_available(host: str = "127.0.0.1", port: int = 2947) -> bool:
         return False
 
 
+class NullGps:
+    """No-op GPS provider for systems without GPS hardware."""
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def get_location(self) -> tuple[float, float] | None:
+        return None
+
+    def set_callback(self, callback: Callable[[float, float], None] | None) -> None:
+        pass
+
+    def poll(self) -> bool:
+        return True
+
+    def get_last_error(self) -> str | None:
+        return None
+
+    def has_fix(self) -> bool:
+        return False
+
+
 def create_gps_provider() -> GpsProvider:
     """Create the appropriate GPS provider for the current environment.
 
@@ -520,7 +545,7 @@ def create_gps_provider() -> GpsProvider:
     1. MESHCORE_MOCK=1 → MockGps
     2. gpsd reachable (unless MESHCORE_GPSD_DISABLE=1) → GpsdProvider
     3. /dev/ttyS0 exists → UConsoleGps
-    4. Fallback → MockGps
+    4. Fallback → NullGps (returns None; callers use settings fixed position)
     """
     if os.environ.get("MESHCORE_MOCK", "0") == "1":
         from meshcore_console.mock import MockGps
@@ -539,7 +564,5 @@ def create_gps_provider() -> GpsProvider:
     if Path("/dev/ttyS0").exists():
         return UConsoleGps()
 
-    # Fall back to mock
-    from meshcore_console.mock import MockGps
-
-    return MockGps()
+    logger.debug("GPS: no hardware detected, using NullGps")
+    return NullGps()

--- a/tests/unit/test_gps.py
+++ b/tests/unit/test_gps.py
@@ -122,6 +122,8 @@ def test_create_gps_provider_prefers_gpsd_when_available() -> None:
 
 
 def test_create_gps_provider_respects_gpsd_disable() -> None:
+    from meshcore_console.platform.gps import NullGps
+
     env = {"MESHCORE_MOCK": "0", "MESHCORE_GPSD_DISABLE": "1"}
     with (
         patch.dict(os.environ, env, clear=False),
@@ -132,10 +134,8 @@ def test_create_gps_provider_respects_gpsd_disable() -> None:
         provider = create_gps_provider()
         # gpsd should not even be checked
         mock_avail.assert_not_called()
-        # Should fall through to mock since /dev/ttyS0 doesn't exist
-        from meshcore_console.mock.gps import MockGps
-
-        assert isinstance(provider, MockGps)
+        # Should fall through to NullGps since serial device doesn't exist
+        assert isinstance(provider, NullGps)
 
 
 def test_create_gps_provider_falls_back_to_serial() -> None:


### PR DESCRIPTION
## Summary

Closes #51

- Replace `MockGps` production fallback with `NullGps` so callers fall through to settings lat/lon instead of hardcoded San Francisco coordinates
- Pass settings-configured lat/lon to `send_advert()`, `_get_local_telemetry()`, and `get_device_location()` when `share_position` is enabled and no live GPS is available
- Extract `_resolve_position()` helper to unify the GPS → settings fallback across all three callsites
- Treat `(0.0, 0.0)` as "unset" to avoid placing nodes at the equator/prime-meridian intersection

Based on work by @SoulOfNoob in their fork.

## Test plan

- [ ] Set fixed lat/lon in Settings → Public Info, enable Share GPS Position
- [ ] Send advert → verify coordinates match settings (not SF / 0,0)
- [ ] Request telemetry from another node → verify reported position matches
- [ ] Check map marker → verify it shows configured position
- [ ] With `MESHCORE_MOCK=1` → verify mock GPS still works as before
- [ ] Unit tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)