### PR TITLE
feat: Telemetry improvements — voltage, ANON_REQ handling, UI caching

### DIFF
--- a/src/meshcore_console/meshcore/cayenne_lpp.py
+++ b/src/meshcore_console/meshcore/cayenne_lpp.py
@@ -17,6 +17,23 @@ def encode_gps(channel: int, lat: float, lon: float, alt: float = 0.0) -> bytes:
     return bytes(frame)
 
 
+def encode_telemetry(
+    channel: int,
+    *,
+    lat: float | None = None,
+    lon: float | None = None,
+    alt: float = 0.0,
+    voltage: float | None = None,
+) -> bytes:
+    """Encode available telemetry sensors as CayenneLPP bytes."""
+    frame = LppFrame()
+    if voltage is not None:
+        frame.add_voltage(channel, voltage)
+    if lat is not None and lon is not None:
+        frame.add_gps(channel, lat, lon, alt)
+    return bytes(frame)
+
+
 def decode_cayenne_lpp_payload(hex_string: str) -> dict:
     """Decode a CayenneLPP hex payload into structured sensor data.
 

--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -851,7 +851,16 @@ class MeshcoreClient(MeshcoreService):
             "allow": self._settings.allow_telemetry,
             "lat": pos[0] if pos else None,
             "lon": pos[1] if pos else None,
+            "voltage": self._read_battery_voltage(),
         }
+
+    @staticmethod
+    def _read_battery_voltage() -> float | None:
+        try:
+            with open("/sys/class/power_supply/axp20x-battery/voltage_now") as f:
+                return int(f.read().strip()) / 1_000_000
+        except (FileNotFoundError, ValueError, OSError):
+            return None
 
     def _seed_contact_book(self) -> None:
         """Populate the session's contact book with known peers that have public keys."""

--- a/src/meshcore_console/meshcore/contact_book.py
+++ b/src/meshcore_console/meshcore/contact_book.py
@@ -41,6 +41,20 @@ class ContactBook:
                 return contact
         return None
 
+    def get_by_key(self, public_key: bytes | str) -> Contact | None:
+        if isinstance(public_key, bytes):
+            public_key = public_key.hex()
+        for contact in self.contacts:
+            if contact.public_key == public_key:
+                return contact
+        return None
+
+    def update(self, contact: Contact) -> None:
+        for i, existing in enumerate(self.contacts):
+            if existing.public_key == contact.public_key:
+                self.contacts[i] = contact
+                return
+
     def add_contact(self, data: dict[str, str] | Contact) -> None:
         if isinstance(data, Contact):
             entry = data

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -23,7 +23,7 @@ from meshcore_console.core.types import (
     SX1262RadioProtocol,
 )
 
-from .cayenne_lpp import encode_gps
+from .cayenne_lpp import encode_gps, encode_telemetry
 from . import cayenne_lpp as _cayenne_lpp_mod
 
 # pymc_core's ProtocolResponseHandler tries ``from utils.cayenne_lpp_helpers
@@ -70,6 +70,8 @@ class PyMCCoreSession:
     def _log(self, message: str) -> None:
         if self._logger is not None:
             self._logger(message)
+        else:
+            logger.debug(message)
 
     def set_event_notify(self, notify_fn: Callable[[], None]) -> None:
         self._event_notify = notify_fn
@@ -151,53 +153,219 @@ class PyMCCoreSession:
             if not data.get("allow"):
                 self._log("telemetry request denied (allow_telemetry=False)")
                 return None
-            # req_data is an inverse permission mask — bits set = permissions EXCLUDED
             mask = req_data[0] if req_data else 0x00
-            if mask & TELEM_PERM_LOCATION:
-                self._log("telemetry request excludes location")
+            include_location = not (mask & TELEM_PERM_LOCATION)
+            lat = data.get("lat") if include_location else None
+            lon = data.get("lon") if include_location else None
+            voltage = data.get("voltage")
+            payload = encode_telemetry(
+                channel=1, lat=lat, lon=lon, voltage=voltage,
+            )
+            if not payload:
+                self._log("telemetry request: no sensor data available")
                 return None
-            lat = data.get("lat")
-            lon = data.get("lon")
-            if lat is None or lon is None:
-                self._log("telemetry request: no GPS fix")
-                return None
-            payload = encode_gps(channel=1, lat=lat, lon=lon)
-            self._log(f"responding to telemetry request with GPS ({lat:.4f}, {lon:.4f})")
+            self._log(
+                f"responding to telemetry request "
+                f"(voltage={voltage}, lat={lat}, lon={lon})"
+            )
             return payload
 
         return _handle_telemetry
 
     def _register_req_handler(self) -> None:
-        """Register a handler for incoming REQ packets.
+        """Register handlers for incoming REQ and ANON_REQ packets.
 
         pyMC_core's register_default_handlers() does not register a handler
         for PAYLOAD_TYPE_REQ (0x00), so incoming requests are silently
         dropped.  We register ProtocolRequestHandler here and wrap it so
         that any generated RESPONSE packet is actually transmitted.
+
+        ANON_REQ (0x07) packets carry the sender's public key inline, so
+        they don't require prior key exchange.  The default AnonReqResponseHandler
+        only handles login responses; we replace it with one that also handles
+        telemetry requests.
         """
+        import struct
+
         from pymc_core.node.handlers.protocol_request import ProtocolRequestHandler
-        from pymc_core.protocol.constants import PAYLOAD_TYPE_REQ
+        from pymc_core.protocol import CryptoUtils, Identity, PacketBuilder
+        from pymc_core.protocol.constants import (
+            PAYLOAD_TYPE_ANON_REQ,
+            PAYLOAD_TYPE_REQ,
+            PAYLOAD_TYPE_RESPONSE,
+        )
 
         REQ_TYPE_GET_TELEMETRY_DATA = 0x03  # noqa: N806
 
         assert self._node is not None
         assert self._identity is not None
 
+        telemetry_handler = self._build_telemetry_handler()
+        request_handlers = {REQ_TYPE_GET_TELEMETRY_DATA: telemetry_handler}
+
         req_handler = ProtocolRequestHandler(
             local_identity=self._identity,
             contacts=self._contact_book,
             log_fn=self._log,
-            request_handlers={REQ_TYPE_GET_TELEMETRY_DATA: self._build_telemetry_handler()},
+            request_handlers=request_handlers,
         )
 
         dispatcher = self._node.dispatcher
 
+        identity = self._identity
+        contact_book = self._contact_book
+
         async def _handle_req(pkt: Any) -> None:
-            response_pkt = await req_handler(pkt)
-            if response_pkt is not None:
-                await dispatcher.send_packet(response_pkt, wait_for_ack=False)
+            # ProtocolRequestHandler._get_client matches on first byte only,
+            # which collides when multiple contacts share a hash prefix.
+            # Try each matching contact until decryption succeeds.
+            if len(pkt.payload) < 2:
+                return
+            dest_hash = pkt.payload[0]
+            src_hash = pkt.payload[1]
+            our_hash = identity.get_public_key()[0]
+            if dest_hash != our_hash:
+                return
+
+            encrypted_data = bytes(pkt.payload[2:])
+            candidates = [
+                c for c in contact_book.contacts
+                if c.public_key and bytes.fromhex(c.public_key)[0] == src_hash
+            ]
+            if not candidates:
+                self._log(f"REQ from unknown 0x{src_hash:02X}")
+                return
+
+            for contact in candidates:
+                peer_id = Identity(bytes.fromhex(contact.public_key))
+                ss = peer_id.calc_shared_secret(identity.get_private_key())
+                aes_key = ss[:16]
+                try:
+                    plaintext = CryptoUtils.mac_then_decrypt(
+                        aes_key, ss, encrypted_data,
+                    )
+                except Exception:
+                    continue
+
+                if len(plaintext) < 5:
+                    continue
+                timestamp = struct.unpack("<I", plaintext[0:4])[0]
+                req_type = plaintext[4]
+                req_data = plaintext[5:] if len(plaintext) > 5 else b""
+                self._log(
+                    f"REQ from {contact.name} (0x{src_hash:02X}) "
+                    f"type=0x{req_type:02X} ts={timestamp}"
+                )
+
+                handler_fn = request_handlers.get(req_type)
+                if handler_fn is None:
+                    self._log(f"REQ: no handler for type 0x{req_type:02X}")
+                    return
+
+                response_payload = handler_fn(contact, timestamp, req_data)
+                if response_payload is None:
+                    self._log("REQ: handler returned no data")
+                    return
+
+                response_pkt = req_handler._build_response(
+                    pkt, contact, struct.pack("<I", timestamp) + response_payload, ss,
+                )
+                if response_pkt is not None:
+                    logger.debug(
+                        "REQ handler: sending response (%d bytes)",
+                        len(response_pkt.payload),
+                    )
+                    await dispatcher.send_packet(response_pkt, wait_for_ack=False)
+                return
+
+            self._log(
+                f"REQ from 0x{src_hash:02X}: HMAC failed for all "
+                f"{len(candidates)} candidate(s)"
+            )
 
         dispatcher.register_handler(PAYLOAD_TYPE_REQ, _handle_req)
+
+        # --- ANON_REQ handler ---
+        our_pubkey = self._identity.get_public_key()
+        our_hash = our_pubkey[0]
+        our_privkey = self._identity.get_private_key()
+        existing_anon = dispatcher._handler_instances.get(PAYLOAD_TYPE_ANON_REQ)
+
+        async def _handle_anon_req(pkt: Any) -> None:
+            if len(pkt.payload) < 34:
+                return
+
+            # Login response check: sender included OUR pubkey → delegate
+            if pkt.payload[1:33] == our_pubkey and existing_anon is not None:
+                await existing_anon(pkt)
+                return
+
+            dest_hash = pkt.payload[0]
+            if dest_hash != our_hash:
+                return
+
+            client_pubkey = bytes(pkt.payload[1:33])
+            encrypted_data = bytes(pkt.payload[33:])
+            client_identity = Identity(client_pubkey)
+            shared_secret = client_identity.calc_shared_secret(our_privkey)
+            aes_key = shared_secret[:16]
+
+            try:
+                plaintext = CryptoUtils.mac_then_decrypt(
+                    aes_key, shared_secret, encrypted_data,
+                )
+            except Exception as e:
+                self._log(f"ANON_REQ decrypt failed: {e}")
+                return
+
+            if len(plaintext) < 5:
+                self._log("ANON_REQ payload too short")
+                return
+
+            timestamp = struct.unpack("<I", plaintext[0:4])[0]
+            req_type = plaintext[4]
+            req_data = plaintext[5:] if len(plaintext) > 5 else b""
+            self._log(
+                f"ANON_REQ from {client_pubkey[:4].hex()}... "
+                f"type=0x{req_type:02X} ts={timestamp}"
+            )
+
+            handler_fn = request_handlers.get(req_type)
+            if handler_fn is None:
+                self._log(f"ANON_REQ: no handler for type 0x{req_type:02X}")
+                return
+
+            response_payload = handler_fn(None, timestamp, req_data)
+            if response_payload is None:
+                self._log("ANON_REQ: handler returned no data")
+                return
+
+            reply_data = struct.pack("<I", timestamp) + response_payload
+            client_hash = client_pubkey[0]
+            path_list = (
+                list(pkt.path[: pkt.path_len])
+                if pkt.path_len > 0
+                else []
+            )
+
+            try:
+                response_pkt = PacketBuilder.create_path_return(
+                    dest_hash=client_hash,
+                    src_hash=our_hash,
+                    secret=shared_secret,
+                    path=path_list,
+                    extra_type=PAYLOAD_TYPE_RESPONSE,
+                    extra=bytes(reply_data),
+                )
+                self._log(
+                    f"ANON_REQ: sending PATH response to "
+                    f"0x{client_hash:02X} ({len(response_pkt.payload)} bytes)"
+                )
+                await dispatcher.send_packet(response_pkt, wait_for_ack=False)
+            except Exception as e:
+                self._log(f"ANON_REQ: failed to build/send response: {e}")
+
+        dispatcher.register_handler(PAYLOAD_TYPE_ANON_REQ, _handle_anon_req)
 
     async def _call_maybe_async(self, target: Any, name: str) -> None:
         fn = getattr(target, name, None)

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -23,7 +23,7 @@ from meshcore_console.core.types import (
     SX1262RadioProtocol,
 )
 
-from .cayenne_lpp import encode_gps, encode_telemetry
+from .cayenne_lpp import encode_telemetry
 from . import cayenne_lpp as _cayenne_lpp_mod
 
 # pymc_core's ProtocolResponseHandler tries ``from utils.cayenne_lpp_helpers
@@ -214,6 +214,9 @@ class PyMCCoreSession:
 
         identity = self._identity
         contact_book = self._contact_book
+        our_pubkey = identity.get_public_key()
+        our_hash = our_pubkey[0]
+        our_privkey = identity.get_private_key()
 
         async def _handle_req(pkt: Any) -> None:
             # ProtocolRequestHandler._get_client matches on first byte only,
@@ -223,7 +226,6 @@ class PyMCCoreSession:
                 return
             dest_hash = pkt.payload[0]
             src_hash = pkt.payload[1]
-            our_hash = identity.get_public_key()[0]
             if dest_hash != our_hash:
                 return
 
@@ -238,7 +240,7 @@ class PyMCCoreSession:
 
             for contact in candidates:
                 peer_id = Identity(bytes.fromhex(contact.public_key))
-                ss = peer_id.calc_shared_secret(identity.get_private_key())
+                ss = peer_id.calc_shared_secret(our_privkey)
                 aes_key = ss[:16]
                 try:
                     plaintext = CryptoUtils.mac_then_decrypt(
@@ -286,9 +288,6 @@ class PyMCCoreSession:
         dispatcher.register_handler(PAYLOAD_TYPE_REQ, _handle_req)
 
         # --- ANON_REQ handler ---
-        our_pubkey = self._identity.get_public_key()
-        our_hash = our_pubkey[0]
-        our_privkey = self._identity.get_private_key()
         existing_anon = dispatcher._handler_instances.get(PAYLOAD_TYPE_ANON_REQ)
 
         async def _handle_anon_req(pkt: Any) -> None:
@@ -325,8 +324,10 @@ class PyMCCoreSession:
             timestamp = struct.unpack("<I", plaintext[0:4])[0]
             req_type = plaintext[4]
             req_data = plaintext[5:] if len(plaintext) > 5 else b""
+            contact = contact_book.get_by_key(client_pubkey)
+            sender = contact.name if contact else f"{client_pubkey[:4].hex()}..."
             self._log(
-                f"ANON_REQ from {client_pubkey[:4].hex()}... "
+                f"ANON_REQ from {sender} "
                 f"type=0x{req_type:02X} ts={timestamp}"
             )
 
@@ -335,7 +336,7 @@ class PyMCCoreSession:
                 self._log(f"ANON_REQ: no handler for type 0x{req_type:02X}")
                 return
 
-            response_payload = handler_fn(None, timestamp, req_data)
+            response_payload = handler_fn(contact, timestamp, req_data)
             if response_payload is None:
                 self._log("ANON_REQ: handler returned no data")
                 return

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -159,15 +159,15 @@ class PyMCCoreSession:
             lon = data.get("lon") if include_location else None
             voltage = data.get("voltage")
             payload = encode_telemetry(
-                channel=1, lat=lat, lon=lon, voltage=voltage,
+                channel=1,
+                lat=lat,
+                lon=lon,
+                voltage=voltage,
             )
             if not payload:
                 self._log("telemetry request: no sensor data available")
                 return None
-            self._log(
-                f"responding to telemetry request "
-                f"(voltage={voltage}, lat={lat}, lon={lon})"
-            )
+            self._log(f"responding to telemetry request (voltage={voltage}, lat={lat}, lon={lon})")
             return payload
 
         return _handle_telemetry
@@ -231,7 +231,8 @@ class PyMCCoreSession:
 
             encrypted_data = bytes(pkt.payload[2:])
             candidates = [
-                c for c in contact_book.contacts
+                c
+                for c in contact_book.contacts
                 if c.public_key and bytes.fromhex(c.public_key)[0] == src_hash
             ]
             if not candidates:
@@ -244,7 +245,9 @@ class PyMCCoreSession:
                 aes_key = ss[:16]
                 try:
                     plaintext = CryptoUtils.mac_then_decrypt(
-                        aes_key, ss, encrypted_data,
+                        aes_key,
+                        ss,
+                        encrypted_data,
                     )
                 except Exception:
                     continue
@@ -270,7 +273,10 @@ class PyMCCoreSession:
                     return
 
                 response_pkt = req_handler._build_response(
-                    pkt, contact, struct.pack("<I", timestamp) + response_payload, ss,
+                    pkt,
+                    contact,
+                    struct.pack("<I", timestamp) + response_payload,
+                    ss,
                 )
                 if response_pkt is not None:
                     logger.debug(
@@ -281,8 +287,7 @@ class PyMCCoreSession:
                 return
 
             self._log(
-                f"REQ from 0x{src_hash:02X}: HMAC failed for all "
-                f"{len(candidates)} candidate(s)"
+                f"REQ from 0x{src_hash:02X}: HMAC failed for all {len(candidates)} candidate(s)"
             )
 
         dispatcher.register_handler(PAYLOAD_TYPE_REQ, _handle_req)
@@ -311,7 +316,9 @@ class PyMCCoreSession:
 
             try:
                 plaintext = CryptoUtils.mac_then_decrypt(
-                    aes_key, shared_secret, encrypted_data,
+                    aes_key,
+                    shared_secret,
+                    encrypted_data,
                 )
             except Exception as e:
                 self._log(f"ANON_REQ decrypt failed: {e}")
@@ -326,10 +333,7 @@ class PyMCCoreSession:
             req_data = plaintext[5:] if len(plaintext) > 5 else b""
             contact = contact_book.get_by_key(client_pubkey)
             sender = contact.name if contact else f"{client_pubkey[:4].hex()}..."
-            self._log(
-                f"ANON_REQ from {sender} "
-                f"type=0x{req_type:02X} ts={timestamp}"
-            )
+            self._log(f"ANON_REQ from {sender} type=0x{req_type:02X} ts={timestamp}")
 
             handler_fn = request_handlers.get(req_type)
             if handler_fn is None:
@@ -343,11 +347,7 @@ class PyMCCoreSession:
 
             reply_data = struct.pack("<I", timestamp) + response_payload
             client_hash = client_pubkey[0]
-            path_list = (
-                list(pkt.path[: pkt.path_len])
-                if pkt.path_len > 0
-                else []
-            )
+            path_list = list(pkt.path[: pkt.path_len]) if pkt.path_len > 0 else []
 
             try:
                 response_pkt = PacketBuilder.create_path_return(

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -144,6 +144,7 @@ class PyMCCoreSession:
 
     def _build_telemetry_handler(self) -> Callable[..., bytes | None]:
         """Build a handler closure for inbound telemetry requests (REQ type 0x03)."""
+        TELEM_PERM_BASE = 0x01  # noqa: N806
         TELEM_PERM_LOCATION = 0x02  # noqa: N806
 
         def _handle_telemetry(_client: Any, _timestamp: int, req_data: bytes) -> bytes | None:
@@ -154,10 +155,11 @@ class PyMCCoreSession:
                 self._log("telemetry request denied (allow_telemetry=False)")
                 return None
             mask = req_data[0] if req_data else 0x00
+            include_base = not (mask & TELEM_PERM_BASE)
             include_location = not (mask & TELEM_PERM_LOCATION)
             lat = data.get("lat") if include_location else None
             lon = data.get("lon") if include_location else None
-            voltage = data.get("voltage")
+            voltage = data.get("voltage") if include_base else None
             payload = encode_telemetry(
                 channel=1,
                 lat=lat,
@@ -299,13 +301,12 @@ class PyMCCoreSession:
             if len(pkt.payload) < 34:
                 return
 
-            # Login response check: sender included OUR pubkey → delegate
-            if pkt.payload[1:33] == our_pubkey and existing_anon is not None:
-                await existing_anon(pkt)
-                return
-
             dest_hash = pkt.payload[0]
             if dest_hash != our_hash:
+                # Not addressed to us — delegate to existing handler
+                # (e.g. login responses where dest_hash is a repeater)
+                if existing_anon is not None:
+                    await existing_anon(pkt)
                 return
 
             client_pubkey = bytes(pkt.payload[1:33])
@@ -322,23 +323,30 @@ class PyMCCoreSession:
                 )
             except Exception as e:
                 self._log(f"ANON_REQ decrypt failed: {e}")
+                if existing_anon is not None:
+                    await existing_anon(pkt)
                 return
 
             if len(plaintext) < 5:
                 self._log("ANON_REQ payload too short")
+                if existing_anon is not None:
+                    await existing_anon(pkt)
                 return
 
             timestamp = struct.unpack("<I", plaintext[0:4])[0]
             req_type = plaintext[4]
             req_data = plaintext[5:] if len(plaintext) > 5 else b""
-            contact = contact_book.get_by_key(client_pubkey)
-            sender = contact.name if contact else f"{client_pubkey[:4].hex()}..."
-            self._log(f"ANON_REQ from {sender} type=0x{req_type:02X} ts={timestamp}")
 
             handler_fn = request_handlers.get(req_type)
             if handler_fn is None:
-                self._log(f"ANON_REQ: no handler for type 0x{req_type:02X}")
+                # Not a request type we handle (e.g. login) — delegate
+                if existing_anon is not None:
+                    await existing_anon(pkt)
                 return
+
+            contact = contact_book.get_by_key(client_pubkey)
+            sender = contact.name if contact else f"{client_pubkey[:4].hex()}..."
+            self._log(f"ANON_REQ from {sender} type=0x{req_type:02X} ts={timestamp}")
 
             response_payload = handler_fn(contact, timestamp, req_data)
             if response_payload is None:

--- a/src/meshcore_console/ui_gtk/views/peers.py
+++ b/src/meshcore_console/ui_gtk/views/peers.py
@@ -55,6 +55,7 @@ class PeersView(Gtk.Box):
         self._event_store = event_store
         self._last_peer_snapshot: str = ""
         self._selected_peer: Peer | None = None
+        self._peer_telemetry: dict[str, dict] = {}
 
         # Column 1: Contacts
         contacts_column = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -317,6 +318,11 @@ class PeersView(Gtk.Box):
         key_label.set_selectable(True)
         self._details_content.append(key_label)
 
+        # === Cached Telemetry ===
+        cached = self._peer_telemetry.get(peer.peer_id)
+        if cached is not None:
+            self._render_telemetry(cached)
+
         # === Action buttons ===
         actions = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         actions.set_margin_top(16)
@@ -410,7 +416,7 @@ class PeersView(Gtk.Box):
                 result = self._service.request_telemetry(peer.display_name)
                 GLib.idle_add(self._show_telemetry_result, spinner_box, button, peer, result)
             except Exception as exc:
-                GLib.idle_add(self._show_telemetry_error, spinner_box, button, str(exc))
+                GLib.idle_add(self._show_telemetry_error, spinner_box, button, peer, str(exc))
 
         threading.Thread(target=_do_request, daemon=True, name="telemetry-req").start()
 
@@ -418,10 +424,51 @@ class PeersView(Gtk.Box):
         self, spinner_box: Gtk.Box, button: Gtk.Button, peer: Peer, result: dict
     ) -> None:
         """Display telemetry results in the details panel (called on main thread)."""
-        self._details_content.remove(spinner_box)
+        self._peer_telemetry[peer.peer_id] = result
+
+        if self._selected_peer is None or self._selected_peer.peer_id != peer.peer_id:
+            return
+
+        if spinner_box.get_parent() is not None:
+            self._details_content.remove(spinner_box)
         button.set_sensitive(True)
         button.set_label("Request Telemetry")
 
+        self._render_telemetry(result)
+        self._scroll_details_to_bottom()
+
+    def _show_telemetry_error(
+        self, spinner_box: Gtk.Box, button: Gtk.Button, peer: Peer, error: str
+    ) -> None:
+        """Display telemetry error in the details panel (called on main thread)."""
+        if self._selected_peer is None or self._selected_peer.peer_id != peer.peer_id:
+            return
+
+        if spinner_box.get_parent() is not None:
+            self._details_content.remove(spinner_box)
+        button.set_sensitive(True)
+        button.set_label("Request Telemetry")
+
+        self._add_section_header("Telemetry")
+
+        err_scroll = Gtk.ScrolledWindow()
+        err_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        err_scroll.set_max_content_height(120)
+        err_scroll.set_propagate_natural_height(True)
+
+        err_label = Gtk.Label(label=f"Request failed: {error}")
+        err_label.add_css_class("panel-muted")
+        err_label.set_halign(Gtk.Align.START)
+        err_label.set_wrap(True)
+        err_label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
+        err_label.set_selectable(True)
+        err_scroll.set_child(err_label)
+        self._details_content.append(err_scroll)
+
+        self._scroll_details_to_bottom()
+
+    def _render_telemetry(self, result: dict) -> None:
+        """Render telemetry data widgets into the details panel."""
         self._add_section_header("Telemetry")
 
         if not result or not result.get("success"):
@@ -430,7 +477,6 @@ class PeersView(Gtk.Box):
             no_data.add_css_class("panel-muted")
             no_data.set_halign(Gtk.Align.START)
             self._details_content.append(no_data)
-            self._scroll_details_to_bottom()
             return
 
         rtt = result.get("rtt_ms")
@@ -446,7 +492,6 @@ class PeersView(Gtk.Box):
             fallback.add_css_class("panel-muted")
             fallback.set_halign(Gtk.Align.START)
             self._details_content.append(fallback)
-            self._scroll_details_to_bottom()
             return
 
         for sensor in sensors:
@@ -472,32 +517,6 @@ class PeersView(Gtk.Box):
                 self._details_content.append(DetailRow("Pressure:", f"{value:.1f} hPa"))
             else:
                 self._details_content.append(DetailRow(f"{sensor_type}:", str(value)))
-
-        self._scroll_details_to_bottom()
-
-    def _show_telemetry_error(self, spinner_box: Gtk.Box, button: Gtk.Button, error: str) -> None:
-        """Display telemetry error in the details panel (called on main thread)."""
-        self._details_content.remove(spinner_box)
-        button.set_sensitive(True)
-        button.set_label("Request Telemetry")
-
-        self._add_section_header("Telemetry")
-
-        err_scroll = Gtk.ScrolledWindow()
-        err_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        err_scroll.set_max_content_height(120)
-        err_scroll.set_propagate_natural_height(True)
-
-        err_label = Gtk.Label(label=f"Request failed: {error}")
-        err_label.add_css_class("panel-muted")
-        err_label.set_halign(Gtk.Align.START)
-        err_label.set_wrap(True)
-        err_label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
-        err_label.set_selectable(True)
-        err_scroll.set_child(err_label)
-        self._details_content.append(err_scroll)
-
-        self._scroll_details_to_bottom()
 
     def _scroll_details_to_bottom(self) -> None:
         """Scroll the details panel to the bottom after content is added."""

--- a/src/meshcore_console/ui_gtk/views/peers.py
+++ b/src/meshcore_console/ui_gtk/views/peers.py
@@ -413,9 +413,12 @@ class PeersView(Gtk.Box):
 
         def _do_request() -> None:
             try:
+                logger.debug("telemetry request starting for peer=%s", peer.display_name)
                 result = self._service.request_telemetry(peer.display_name)
+                logger.debug("telemetry request result: %s", result)
                 GLib.idle_add(self._show_telemetry_result, spinner_box, button, peer, result)
             except Exception as exc:
+                logger.exception("telemetry request failed for peer=%s", peer.display_name)
                 GLib.idle_add(self._show_telemetry_error, spinner_box, button, peer, str(exc))
 
         threading.Thread(target=_do_request, daemon=True, name="telemetry-req").start()


### PR DESCRIPTION
## Summary

- **Battery voltage telemetry**: Read voltage from AXP209 PMIC sysfs and include it in CayenneLPP telemetry responses alongside GPS
- **ANON_REQ handler**: Handle telemetry requests from peers that haven't done key exchange — decrypts using the inline public key and responds via PATH_RETURN
- **REQ hash-prefix collision fix**: Try all candidate contacts matching a hash prefix byte instead of taking the first match (pyMC_core's `_get_client` only checks the first byte)
- **ANON_REQ sender identity**: Look up the sender's public key in the ContactBook so logs show the peer name instead of "Unknown"
- **UI telemetry caching**: Cache telemetry results per-peer so re-selecting a peer shows previous results; guard against stale widget removal when peer selection changes mid-request
- **ContactBook**: Add `get_by_key()` and `update()` methods for public-key-based lookup

## Test plan

- [ ] Request telemetry from a peer via REQ (known contact) — verify response includes voltage + GPS
- [ ] Request telemetry from a peer via ANON_REQ (no prior key exchange) — verify response is received
- [ ] Check logs show peer name (not hex prefix) for ANON_REQ senders in the contact book
- [ ] Re-select a peer after telemetry request — verify cached result is shown
- [ ] Switch peers while a telemetry request is in-flight — verify no widget crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)