### PR TITLE
feat: Telemetry favorites-only filter

### DIFF
--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -173,8 +173,8 @@ class MeshcoreClient(MeshcoreService):
             self._connected = False
             raise
         self._connected = True
-        self._session.set_telemetry_data_fn(self._get_local_telemetry)
         self._session.set_is_favorite_fn(self._is_peer_favorite)
+        self._session.set_telemetry_data_fn(self._get_local_telemetry)
         self._seed_contact_book()
         self._gps_provider.start()
         self._append_event(
@@ -858,10 +858,11 @@ class MeshcoreClient(MeshcoreService):
 
     def _is_peer_favorite(self, public_key_hex: str) -> bool:
         key_lower = public_key_hex.lower()
-        for peer in self._peers.values():
-            if peer.public_key and peer.public_key.lower() == key_lower:
-                return peer.is_favorite
-        return False
+        return any(
+            peer.is_favorite
+            for peer in self._peers.values()
+            if peer.public_key and peer.public_key.lower() == key_lower
+        )
 
     @staticmethod
     def _read_battery_voltage() -> float | None:

--- a/src/meshcore_console/meshcore/client.py
+++ b/src/meshcore_console/meshcore/client.py
@@ -174,6 +174,7 @@ class MeshcoreClient(MeshcoreService):
             raise
         self._connected = True
         self._session.set_telemetry_data_fn(self._get_local_telemetry)
+        self._session.set_is_favorite_fn(self._is_peer_favorite)
         self._seed_contact_book()
         self._gps_provider.start()
         self._append_event(
@@ -849,10 +850,18 @@ class MeshcoreClient(MeshcoreService):
         pos = self._resolve_position(use_settings=self._settings.allow_telemetry)
         return {
             "allow": self._settings.allow_telemetry,
+            "favorites_only": self._settings.telemetry_favorites_only,
             "lat": pos[0] if pos else None,
             "lon": pos[1] if pos else None,
             "voltage": self._read_battery_voltage(),
         }
+
+    def _is_peer_favorite(self, public_key_hex: str) -> bool:
+        key_lower = public_key_hex.lower()
+        for peer in self._peers.values():
+            if peer.public_key and peer.public_key.lower() == key_lower:
+                return peer.is_favorite
+        return False
 
     @staticmethod
     def _read_battery_voltage() -> float | None:

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -160,9 +160,8 @@ class PyMCCoreSession:
                 self._log("telemetry request denied (allow_telemetry=False)")
                 return None
             if data.get("favorites_only") and self._is_favorite_fn is not None:
-                pubkey_hex = getattr(client, "public_key", None) if client else None
-                if not pubkey_hex or not self._is_favorite_fn(pubkey_hex):
-                    sender = getattr(client, "name", "unknown") if client else "unknown"
+                if not client or not self._is_favorite_fn(client.public_key):
+                    sender = client.name if client else "unknown"
                     self._log(f"telemetry request denied (not a favorite: {sender})")
                     return None
             mask = req_data[0] if req_data else 0x00

--- a/src/meshcore_console/meshcore/session.py
+++ b/src/meshcore_console/meshcore/session.py
@@ -62,6 +62,7 @@ class PyMCCoreSession:
         self._event_queue: queue.Queue[MeshEventDict] = queue.Queue()
         self._event_notify: Callable[[], None] | None = None
         self._telemetry_data_fn: Callable[[], dict[str, Any]] | None = None
+        self._is_favorite_fn: Callable[[str], bool] | None = None
         self._db = open_db()
         self._channel_db = ChannelDatabase(self._db)
         self._contact_book = ContactBook()
@@ -79,6 +80,10 @@ class PyMCCoreSession:
     def set_telemetry_data_fn(self, fn: Callable[[], dict[str, Any]]) -> None:
         """Set the callback that provides local telemetry data for inbound requests."""
         self._telemetry_data_fn = fn
+
+    def set_is_favorite_fn(self, fn: Callable[[str], bool]) -> None:
+        """Set a callback that checks whether a public key hex belongs to a favorite peer."""
+        self._is_favorite_fn = fn
 
     def _emit(self, payload: MeshEventDict) -> None:
         self._event_queue.put_nowait(payload)
@@ -147,13 +152,19 @@ class PyMCCoreSession:
         TELEM_PERM_BASE = 0x01  # noqa: N806
         TELEM_PERM_LOCATION = 0x02  # noqa: N806
 
-        def _handle_telemetry(_client: Any, _timestamp: int, req_data: bytes) -> bytes | None:
+        def _handle_telemetry(client: Any, _timestamp: int, req_data: bytes) -> bytes | None:
             if self._telemetry_data_fn is None:
                 return None
             data = self._telemetry_data_fn()
             if not data.get("allow"):
                 self._log("telemetry request denied (allow_telemetry=False)")
                 return None
+            if data.get("favorites_only") and self._is_favorite_fn is not None:
+                pubkey_hex = getattr(client, "public_key", None) if client else None
+                if not pubkey_hex or not self._is_favorite_fn(pubkey_hex):
+                    sender = getattr(client, "name", "unknown") if client else "unknown"
+                    self._log(f"telemetry request denied (not a favorite: {sender})")
+                    return None
             mask = req_data[0] if req_data else 0x00
             include_base = not (mask & TELEM_PERM_BASE)
             include_location = not (mask & TELEM_PERM_LOCATION)

--- a/src/meshcore_console/meshcore/settings.py
+++ b/src/meshcore_console/meshcore/settings.py
@@ -11,6 +11,7 @@ class MeshcoreSettings:
     longitude: float = 0.0
     share_position: bool = False  # Share GPS position in adverts
     allow_telemetry: bool = True  # Allow telemetry requests from other nodes
+    telemetry_favorites_only: bool = False
     autoconnect: bool = False  # Automatically connect to radio on app startup
     suppress_service_dialog: bool = False  # Don't prompt to stop conflicting services
     log_level: str = "INFO"  # stderr log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/src/meshcore_console/ui_gtk/views/settings.py
+++ b/src/meshcore_console/ui_gtk/views/settings.py
@@ -131,11 +131,26 @@ class SettingsView(Gtk.Box):
 
         # Row 5: Allow Telemetry
         grid.attach(self._grid_label("Allow Telemetry"), 0, 5, 1, 1)
-        grid.attach(self._grid_switch("allow_telemetry"), 1, 5, 1, 1)
+        allow_telem_switch = self._grid_switch("allow_telemetry")
+        grid.attach(allow_telem_switch, 1, 5, 1, 1)
 
-        # Row 6: Autoconnect
-        grid.attach(self._grid_label("Autoconnect"), 0, 6, 1, 1)
-        grid.attach(self._grid_switch("autoconnect"), 1, 6, 1, 1)
+        # Row 6: Favorites Only (sub-option of Allow Telemetry)
+        fav_label = self._grid_label("Favorites Only")
+        fav_switch = self._grid_switch("telemetry_favorites_only")
+        grid.attach(fav_label, 0, 6, 1, 1)
+        grid.attach(fav_switch, 1, 6, 1, 1)
+
+        def _sync_fav_sensitivity(*_args: object) -> None:
+            active = allow_telem_switch.get_active()
+            fav_label.set_sensitive(active)
+            fav_switch.set_sensitive(active)
+
+        allow_telem_switch.connect("notify::active", _sync_fav_sensitivity)
+        _sync_fav_sensitivity()
+
+        # Row 7: Autoconnect
+        grid.attach(self._grid_label("Autoconnect"), 0, 7, 1, 1)
+        grid.attach(self._grid_switch("autoconnect"), 1, 7, 1, 1)
 
         panel.append(grid)
         return panel
@@ -464,6 +479,7 @@ class SettingsView(Gtk.Box):
         self._set_entry_float("longitude", settings.longitude)
         self._set_switch("share_position", settings.share_position)
         self._set_switch("allow_telemetry", settings.allow_telemetry)
+        self._set_switch("telemetry_favorites_only", settings.telemetry_favorites_only)
         self._set_switch("autoconnect", settings.autoconnect)
 
         # Update public key display
@@ -510,6 +526,7 @@ class SettingsView(Gtk.Box):
         out.longitude = self._parse_float("longitude", allow_partial) or current.longitude
         out.share_position = self._switches["share_position"].get_active()
         out.allow_telemetry = self._switches["allow_telemetry"].get_active()
+        out.telemetry_favorites_only = self._switches["telemetry_favorites_only"].get_active()
         out.autoconnect = self._switches["autoconnect"].get_active()
 
         # Radio


### PR DESCRIPTION
## Summary
- Adds a `telemetry_favorites_only` setting that restricts inbound telemetry responses to only peers marked as favorites
- "Favorites Only" toggle in Settings UI is a sub-option of "Allow Telemetry" and grays out when telemetry is disabled
- Non-favorite requests are denied with a log message identifying the sender

## Test plan
- [ ] Enable "Allow Telemetry" + "Favorites Only", request telemetry from a non-favorite peer → denied
- [ ] Mark that peer as favorite, request again → responded
- [ ] Disable "Allow Telemetry" → "Favorites Only" toggle grays out
- [ ] Settings round-trip: save, reload, verify toggle state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)