### PR TITLE
feat: Add dedupe toggle to analyzer view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,11 @@ Mock implementation is in `meshcore/mock_session.py`. It exercises the same adap
 
 In a git bare-repo worktree the flake isn't at the repo root, so use `nix develop path:.` to point at the current directory's flake.
 
-Prefix every command with `nix develop --command` (or run inside an existing `nix develop` shell):
+Prefix every command with `nix develop path:. --command` (or run inside an existing `nix develop` shell):
 
 ```bash
 nix develop path:. --command uv run pytest
-nix develop path:. --command ./scripts/run-dev.sh
+./scripts/run-dev.sh  # enters nix develop automatically
 ```
 
 ### Common Commands
@@ -159,10 +159,13 @@ All commands below assume you are inside `nix develop`.
 
 ### Initial Setup (macOS)
 
+`run-dev.sh` auto-creates the venv with `--system-site-packages` if missing or misconfigured. To set up manually:
+
 ```bash
-nix develop --command sh -lc 'uv venv --python "$(which python)" --system-site-packages'
-nix develop --command uv sync
+nix develop path:. --command bash -c 'uv venv --python "$(which python)" --system-site-packages && uv sync'
 ```
+
+**Important:** If tests or other tools recreate `.venv` without `--system-site-packages`, PyGObject (`gi`) will be missing and the GTK app will fail to import. Run `./scripts/run-dev.sh` to auto-fix, or re-run the command above.
 
 ### Raspberry Pi Development
 

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 if [[ -z "${IN_NIX_SHELL:-}" ]] && command -v nix >/dev/null 2>&1; then
-  exec nix develop --command "$0" "$@"
+  exec nix develop path:. --command "$0" "$@"
+fi
+
+# Ensure venv exists with system-site-packages (needed for PyGObject from Nix)
+if [[ ! -f .venv/pyvenv.cfg ]] || ! grep -q 'include-system-site-packages = true' .venv/pyvenv.cfg; then
+  echo "Creating venv with --system-site-packages..."
+  uv venv --python "$(which python)" --system-site-packages --clear
+  uv sync
 fi
 
 export MESHCORE_MOCK="${MESHCORE_MOCK:-1}"
-PYTHONPATH=src python -m meshcore_console.main
+uv run python -m meshcore_console.main

--- a/src/meshcore_console/mock/data.py
+++ b/src/meshcore_console/mock/data.py
@@ -243,7 +243,7 @@ def create_mock_packet_events() -> list[dict]:
         return (day - timedelta(seconds=offset_sec)).isoformat()
 
     # Number of "today" packets; the rest are stamped as yesterday
-    TODAY_COUNT = 11
+    TODAY_COUNT = 12
 
     packets = [
         # ADVERT packet - repeater node advertising identity with location
@@ -286,6 +286,26 @@ def create_mock_packet_events() -> list[dict]:
                 "payload_hex": "f589d410abcd1234567890abcdef",
                 "path_len": 2,
                 "path_hops": ["B7", "C2"],
+                "packet_hash": "1234567890AB",
+            },
+        },
+        # GRP_TXT duplicate - same packet_hash as THD Observer above, different route
+        {
+            "type": "packet",
+            "data": {
+                "payload_type": 5,
+                "payload_type_name": "GRP_TXT",
+                "route_type": 1,
+                "route_type_name": "FLOOD",
+                "sender_name": "THD Observer",
+                "sender_id": "f5890d41abcd1234",
+                "channel_name": "public",
+                "payload_text": "@[\U0001f4e1 Relay A] observed at 14:32 UTC",
+                "rssi": -101,
+                "snr": -1.75,
+                "payload_hex": "f589d410abcd1234567890abcdef",
+                "path_len": 3,
+                "path_hops": ["B7", "D4", "C2"],
                 "packet_hash": "1234567890AB",
             },
         },

--- a/src/meshcore_console/ui_gtk/views/analyzer.py
+++ b/src/meshcore_console/ui_gtk/views/analyzer.py
@@ -66,6 +66,7 @@ class AnalyzerView(Gtk.Box):
         self._packets: deque[PacketRecord] = deque(maxlen=400)
         self._selected_packet: PacketRecord | None = None
         self._paused = False
+        self._dedupe = False
         self._active_filter = AnalyzerFilter.ALL
 
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -82,6 +83,13 @@ class AnalyzerView(Gtk.Box):
             self._filter_buttons[filter_type] = button
             toolbar.append(button)
         self._filter_buttons[AnalyzerFilter.ALL].set_active(True)
+
+        # Dedupe toggle
+        self._dedupe_btn = Gtk.ToggleButton.new_with_label("DEDUPE")
+        self._dedupe_btn.add_css_class("analyzer-filter")
+        self._dedupe_btn.set_tooltip_text("Hide duplicate packets (same hash, different hops)")
+        self._dedupe_btn.connect("toggled", self._on_dedupe_toggled)
+        toolbar.append(self._dedupe_btn)
 
         # Spacer to push play/pause to the right
         spacer = Gtk.Box()
@@ -189,6 +197,10 @@ class AnalyzerView(Gtk.Box):
         else:
             self._pause_icon.set_from_icon_name("media-playback-pause-symbolic")
             button.set_tooltip_text("Pause stream")
+
+    def _on_dedupe_toggled(self, button: Gtk.ToggleButton) -> None:
+        self._dedupe = button.get_active()
+        self._refresh_all()
 
     def _on_filter_clicked(self, _button: Gtk.ToggleButton, filter_type: AnalyzerFilter) -> None:
         logger.debug("UI: filter clicked filter=%s", filter_type.value)
@@ -467,12 +479,26 @@ class AnalyzerView(Gtk.Box):
 
     def _filtered_packets(self) -> list[PacketRecord]:
         if self._active_filter == AnalyzerFilter.ALL:
-            return list(self._packets)
-        filter_val = self._active_filter.value
-        # PATH filter also matches TRACE (both are network diagnostics)
-        if filter_val == "PATH":
-            return [p for p in self._packets if "PATH" in p.packet_type or "TRACE" in p.packet_type]
-        return [p for p in self._packets if filter_val in p.packet_type]
+            packets = list(self._packets)
+        else:
+            filter_val = self._active_filter.value
+            if filter_val == "PATH":
+                packets = [
+                    p for p in self._packets if "PATH" in p.packet_type or "TRACE" in p.packet_type
+                ]
+            else:
+                packets = [p for p in self._packets if filter_val in p.packet_type]
+        if self._dedupe:
+            seen: set[str] = set()
+            deduped: list[PacketRecord] = []
+            for p in packets:
+                if p.packet_hash and p.packet_hash in seen:
+                    continue
+                if p.packet_hash:
+                    seen.add(p.packet_hash)
+                deduped.append(p)
+            return deduped
+        return packets
 
     def _matches_filter(self, record: PacketRecord) -> bool:
         """Check if a record matches the current active filter."""
@@ -489,8 +515,24 @@ class AnalyzerView(Gtk.Box):
 
     def _append_new_rows(self, new_records: list[PacketRecord]) -> None:
         """Incrementally prepend new rows to the stream ListBox."""
-        # Filter new records that match the current filter
-        matching = [r for r in new_records if self._matches_filter(r)]
+        # Filter new records that match the current filter and dedupe.
+        # For dedupe: keep the first of each hash within the new batch, and
+        # suppress any whose hash already existed in the deque before this batch.
+        new_set = set(id(r) for r in new_records)
+        seen_hashes: set[str] = set()
+        matching: list[PacketRecord] = []
+        for r in new_records:
+            if not self._matches_filter(r):
+                continue
+            if self._dedupe and r.packet_hash:
+                if r.packet_hash in seen_hashes:
+                    continue
+                seen_hashes.add(r.packet_hash)
+                if any(
+                    p.packet_hash == r.packet_hash for p in self._packets if id(p) not in new_set
+                ):
+                    continue
+            matching.append(r)
         if not matching:
             return
 


### PR DESCRIPTION
## Summary
- Adds a DEDUPE toggle button to the analyzer toolbar that hides duplicate packets (same `packet_hash` arriving via different hop paths)
- Adds a duplicate mock packet with different routing for testing
- Fixes `run-dev.sh` to auto-create the venv with `--system-site-packages` when missing, and uses `nix develop path:.` for worktree compatibility

## Test plan
- [ ] Run `./scripts/run-dev.sh` — app should launch without manual venv setup
- [ ] Open analyzer view, verify duplicate THD Observer packets appear (2-hop and 3-hop)
- [ ] Toggle DEDUPE on — one of the duplicates should disappear
- [ ] Toggle DEDUPE off — both reappear

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)