### PR TITLE
fix: Replace hallucinated repeater admin commands with real ones

### DIFF
--- a/src/meshcore_console/mock/data.py
+++ b/src/meshcore_console/mock/data.py
@@ -38,44 +38,22 @@ MOCK_GPS_WAYPOINTS: list[tuple[float, float]] = [
 
 
 MOCK_CLI_RESPONSES: dict[str, str] = {
-    "status": (
-        "Uptime: 3d 14h 22m\n"
-        "Connected clients: 7\n"
-        "Packets forwarded: 12,847\n"
-        "Frequency: 910.525 MHz\n"
-        "TX Power: 20 dBm\n"
-        "SF: 10  BW: 250 kHz  CR: 4/5"
-    ),
     "ver": "MeshCore Repeater v1.12.3\nBoard: Heltec V3\nBuild: 2025-04-10",
     "neighbors": (
         "Neighbors (3):\n"
-        "  Alice     -67 dBm  SNR  8.5  direct\n"
-        "  Bob       -82 dBm  SNR  3.2  2 hops\n"
-        "  Charlie   -91 dBm  SNR -1.0  3 hops"
+        "  Alice     -67 dBm  SNR  8.5  0 hops\n"
+        "  Bob       -82 dBm  SNR  3.2  0 hops\n"
+        "  Charlie   -91 dBm  SNR -1.0  0 hops"
     ),
-    "help": (
-        "Available commands:\n"
-        "  status        Show repeater status\n"
-        "  ver           Firmware version\n"
-        "  neighbors     Connected peers\n"
-        "  reboot        Reboot repeater\n"
-        "  advert        Send advertisement\n"
-        "  clock         Show device time\n"
-        "  set           Configure parameters\n"
-        "  get           Query parameters\n"
-        "  log           View packet log"
+    "telemetry": (
+        "Battery: 3.82V (74%)\n"
+        "Temperature: 32.1 C\n"
+        "Humidity: 58%\n"
+        "Uptime: 3d 14h 22m\n"
+        "TX Power: 20 dBm\n"
+        "Packets forwarded: 12,847"
     ),
-    "clock": "Device time: 2025-04-15 14:32:07 UTC\nUptime: 3d 14h 22m",
-    "advert": "Advertisement sent (flood)",
     "reboot": "Rebooting in 3 seconds...",
-    "log": (
-        "Recent packets (last 5):\n"
-        "  14:31:52 ADVERT  Alice      -67 dBm\n"
-        "  14:31:48 GRP_TXT #test      -73 dBm\n"
-        "  14:31:45 TXT_MSG Bob        -82 dBm\n"
-        "  14:31:40 ACK     Charlie    -91 dBm\n"
-        "  14:31:38 ADVERT  Diana      -78 dBm"
-    ),
 }
 
 

--- a/src/meshcore_console/ui_gtk/views/admin.py
+++ b/src/meshcore_console/ui_gtk/views/admin.py
@@ -196,7 +196,7 @@ class AdminView(Gtk.Box):
         quick_row.set_margin_end(8)
         quick_row.set_margin_top(8)
         quick_row.set_margin_bottom(4)
-        for cmd in ("status", "ver", "neighbors", "help", "log"):
+        for cmd in ("neighbors", "telemetry", "reboot", "ver"):
             btn = Gtk.Button.new_with_label(cmd)
             btn.add_css_class("quick-cmd-btn")
             btn.connect("clicked", self._on_quick_cmd, cmd)

--- a/tests/integration/test_repeater_admin.py
+++ b/tests/integration/test_repeater_admin.py
@@ -48,7 +48,7 @@ def test_list_logged_in_repeaters() -> None:
 def test_send_command() -> None:
     client = MockMeshcoreClient()
     client.login_to_repeater("repeater-1", "admin123")
-    result = client.send_repeater_command("repeater-1", "status")
+    result = client.send_repeater_command("repeater-1", "ver")
 
     assert result["success"] is True
     assert "response_text" in result

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "meshcore-uconsole"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "gpsdclient" },


### PR DESCRIPTION
## Summary
- Replaced quick command buttons (`status`, `ver`, `neighbors`, `help`, `log`) with commands matching the official MeshCore app: `neighbors`, `telemetry`, `reboot`, `ver`
- Removed hallucinated mock CLI responses (`status`, `help`, `clock`, `advert`, `log`) and added `telemetry`
- Fixed neighbors mock data to show "0 hops" (zero hop neighbours) matching official app description

## Test plan
- [x] `pytest tests/integration/test_repeater_admin.py tests/unit/test_repeater_store.py` — 13 passed
- [ ] Run in mock mode (`MESHCORE_MOCK=1 ./scripts/run-dev.sh`) and verify console tab buttons match: neighbors, telemetry, reboot, ver

🤖 Generated with [Claude Code](https://claude.com/claude-code)