### PR TITLE
fix(ui): render on libadwaita 1.2 (Debian bookworm) — fixes #83

### DIFF
--- a/src/meshcore_console/ui_gtk/compat.py
+++ b/src/meshcore_console/ui_gtk/compat.py
@@ -1,0 +1,69 @@
+"""libadwaita version-compatibility helpers.
+
+The app is developed against modern libadwaita (``Adw.ToolbarView`` needs
+libadwaita >= 1.4, ``Adw.AlertDialog`` needs >= 1.5) but is also packaged for
+Debian 12 (bookworm), which only ships **libadwaita 1.2**. On 1.2 those symbols
+don't exist, so building the main window raised ``AttributeError`` inside a
+``GLib.idle_add`` callback -- the traceback was swallowed and the app hung on the
+"Loading…" screen forever.
+
+These helpers use the modern widgets when they're available and fall back to
+equivalents that exist in libadwaita 1.2, so the UI builds on both.
+"""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Adw", "1")
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Adw, Gtk  # noqa: E402
+
+#: ``Adw.ToolbarView`` exists since libadwaita 1.4.
+HAS_TOOLBAR_VIEW = hasattr(Adw, "ToolbarView")
+#: ``Adw.AlertDialog`` exists since libadwaita 1.5 (``Adw.MessageDialog`` since 1.2).
+HAS_ALERT_DIALOG = hasattr(Adw, "AlertDialog")
+
+
+def build_toolbar_page(header_bar: Gtk.Widget, content: Gtk.Widget) -> Gtk.Widget:
+    """Return a page with ``header_bar`` above ``content``.
+
+    Uses ``Adw.ToolbarView`` (libadwaita >= 1.4) when available, otherwise a
+    vertical ``Gtk.Box`` (libadwaita 1.2 / bookworm).
+    """
+    if HAS_TOOLBAR_VIEW:
+        page = Adw.ToolbarView.new()
+        page.add_top_bar(header_bar)
+        page.set_content(content)
+        return page
+    page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+    page.append(header_bar)
+    page.append(content)
+    return page
+
+
+def build_alert_dialog(parent: Gtk.Widget, heading: str, body: str | None = None):
+    """Create a confirmation/alert dialog.
+
+    Uses ``Adw.AlertDialog`` (libadwaita >= 1.5) when available, otherwise
+    ``Adw.MessageDialog`` (available since 1.2). Both expose the same
+    ``add_response`` / ``set_response_appearance`` / ``set_default_response`` /
+    ``set_close_response`` / ``set_extra_child`` / ``response`` API, so callers
+    are otherwise identical. Present the result with :func:`present_dialog`.
+    """
+    if HAS_ALERT_DIALOG:
+        return Adw.AlertDialog.new(heading, body)
+    return Adw.MessageDialog.new(parent, heading, body)
+
+
+def present_dialog(dialog, parent: Gtk.Widget) -> None:
+    """Present a dialog created by :func:`build_alert_dialog`.
+
+    ``Adw.AlertDialog.present`` takes the presenting widget; the older
+    ``Adw.MessageDialog.present`` takes no argument (it uses its transient-for).
+    """
+    if HAS_ALERT_DIALOG:
+        dialog.present(parent)
+    else:
+        dialog.present()

--- a/src/meshcore_console/ui_gtk/views/messages.py
+++ b/src/meshcore_console/ui_gtk/views/messages.py
@@ -12,6 +12,7 @@ from gi.repository import Adw, Gdk, GLib, Gtk, Pango
 from meshcore_console.core.models import Channel, Message
 from meshcore_console.core.radio import snr_to_quality
 from meshcore_console.core.services import MeshcoreService
+from meshcore_console.ui_gtk.compat import build_alert_dialog, present_dialog
 from meshcore_console.ui_gtk.helpers import clear_children, clear_listbox, navigate
 from meshcore_console.ui_gtk.layout import Layout
 from meshcore_console.ui_gtk.state import UiEventStore
@@ -625,7 +626,8 @@ class MessagesView(Gtk.Box):
         popover.popdown()
 
         display_name = self._get_channel_display_name(channel_id)
-        dialog = Adw.AlertDialog.new(
+        dialog = build_alert_dialog(
+            self.get_root(),
             f"Remove {display_name}?",
             "This will remove the channel and all its messages. This cannot be undone.",
         )
@@ -635,7 +637,7 @@ class MessagesView(Gtk.Box):
         dialog.set_default_response("cancel")
         dialog.set_close_response("cancel")
         dialog.connect("response", self._on_remove_confirmed, channel_id)
-        dialog.present(self.get_root())
+        present_dialog(dialog, self.get_root())
 
     def _on_remove_confirmed(
         self, _dialog: Adw.AlertDialog, response: str, channel_id: str
@@ -653,7 +655,7 @@ class MessagesView(Gtk.Box):
     def _on_add_channel_clicked(self, _button: Gtk.Button) -> None:
         """Show a dialog to add a new hashtag channel by name."""
         logger.debug("UI: add channel clicked")
-        dialog = Adw.AlertDialog.new("Add Channel", None)
+        dialog = build_alert_dialog(self.get_root(), "Add Channel", None)
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("add", "Add")
         dialog.set_response_appearance("add", Adw.ResponseAppearance.SUGGESTED)
@@ -678,7 +680,7 @@ class MessagesView(Gtk.Box):
 
         dialog.set_extra_child(row)
         dialog.connect("response", self._on_add_channel_response, entry)
-        dialog.present(self.get_root())
+        present_dialog(dialog, self.get_root())
         entry.grab_focus()
 
     def _on_add_channel_response(

--- a/src/meshcore_console/ui_gtk/windows/main_window.py
+++ b/src/meshcore_console/ui_gtk/windows/main_window.py
@@ -20,6 +20,7 @@ from gi.repository import Pango
 
 from meshcore_console.core.services import MeshcoreService
 from meshcore_console.platform.conflicts import ConflictError, ConflictReport
+from meshcore_console.ui_gtk.compat import build_alert_dialog, build_toolbar_page, present_dialog
 from meshcore_console.ui_gtk.state import UiEventStore
 from meshcore_console.ui_gtk.widgets import ConflictScreen, LoadingScreen, StatusPill
 
@@ -95,9 +96,7 @@ class MainWindow(Adw.ApplicationWindow):
         content_pane.set_vexpand(True)
         content_pane.append(self._stack)
 
-        page = Adw.ToolbarView.new()
-        page.add_top_bar(header_bar)
-        page.set_content(content_pane)
+        page = build_toolbar_page(header_bar, content_pane)
 
         self._toast_overlay = Adw.ToastOverlay.new()
         self._toast_overlay.set_child(page)
@@ -626,7 +625,8 @@ class MainWindow(Adw.ApplicationWindow):
             return
         svc = service_names[0]
 
-        dialog = Adw.AlertDialog.new(
+        dialog = build_alert_dialog(
+            self,
             f"{svc} is running",
             (
                 f"The {svc} service is using the radio hardware. "
@@ -640,7 +640,7 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.set_default_response("stop")
         dialog.set_close_response("cancel")
         dialog.connect("response", self._on_service_dialog_response, svc)
-        dialog.present(self)
+        present_dialog(dialog, self)
 
     def _on_service_dialog_response(
         self, dialog: Adw.AlertDialog, response: str, service_name: str


### PR DESCRIPTION
Fixes #83.

## Problem

On Debian 12 (bookworm) the app hangs on the **"Loading…"** screen and the main UI never appears. `_build_main_ui` calls `Adw.ToolbarView.new()` (libadwaita ≥ 1.4), which doesn't exist in bookworm's **libadwaita 1.2** → `AttributeError` inside a `GLib.idle_add` callback → the traceback is swallowed to `~/.xsession-errors` and the content stack never switches from `"loading"` to `"main"`. The dialog code also uses `Adw.AlertDialog` (libadwaita ≥ 1.5), which fails the same way when a dialog is shown.

This affects the primary target platform (ClockworkPi uConsole + HackerGadgets AIO on Raspberry Pi OS / Debian 12) and reproduces on both 1.9.1 and 1.11.0.

## Fix

Add `ui_gtk/compat.py` with small **feature-detected** helpers and route the four call sites through them:

| Modern API (used when present) | Fallback on libadwaita 1.2 |
|---|---|
| `Adw.ToolbarView` (≥ 1.4) | vertical `Gtk.Box` (header bar above content) |
| `Adw.AlertDialog` (≥ 1.5) | `Adw.MessageDialog` (since 1.2) |

`Adw.AlertDialog` and `Adw.MessageDialog` share the same `add_response` / `set_response_appearance` / `set_default_response` / `set_close_response` / `set_extra_child` / `"response"` API; only construction (parent argument) and `present()` differ, which the helpers absorb. **No behavior change on modern libadwaita** — the modern widgets are still used whenever they exist.

Call sites updated:
- `ui_gtk/windows/main_window.py` — main window layout + conflict-service dialog
- `ui_gtk/views/messages.py` — remove-channel and add-channel dialogs

## Testing

- ✅ Confirmed the failure and the fix on real hardware: ClockworkPi uConsole (CM5), Debian 12, kernel `7.1.3-v8-16k+`, libadwaita **1.2.2**. Before: stuck on "Loading…" with the `Adw.ToolbarView` `AttributeError` in `~/.xsession-errors`. After: the equivalent change makes the UI build and render past that point.
- ✅ `compat` module imports under libadwaita 1.2 and reports `HAS_TOOLBAR_VIEW=False` / `HAS_ALERT_DIALOG=False`, exercising the fallback paths.
- ✅ `py_compile` passes on all three files.
- ⚠️ I couldn't run the Nix `uv run pytest` suite in this environment (no Nix on the device). Happy to adjust to match project conventions — e.g. if you'd prefer to instead bump the declared libadwaita/GTK dependency and drop the bookworm target, I can rework it that way.

## Note

There's a second, separate issue on this hardware: `pymc_core`/the app hardcode `/dev/gpiochip0` for the SX1262 RESET/BUSY/IRQ lines, which breaks on kernels where the RP1 header GPIO isn't `gpiochip0` (it's `gpiochip15` here). Filing that separately — not part of this PR.
